### PR TITLE
Speed up hyperlink replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ You can manually process Wikipedia dump file and train a skip-gram model on the 
 - gensim
 - logzero
 - MeCab and its Python binding (mecab-python3) (optional: required for tokenizing Japanese texts)
+- regex
 
 
 ### Steps

--- a/make_corpus.py
+++ b/make_corpus.py
@@ -3,6 +3,7 @@ import json
 import gzip
 import argparse
 from collections import OrderedDict
+import regex as re2
 
 from logzero import logger
 
@@ -86,21 +87,16 @@ def main(args):
             hyperlinks_sorted = OrderedDict(sorted(
                 hyperlinks.items(), key=lambda t: len(t[0]), reverse=True))
 
-            replacement_flags = [0] * len(text)
-            for (anchor, entity) in hyperlinks_sorted.items():
-                cursor = 0
-                while cursor < len(text) and anchor in text[cursor:]:
-                    start = text.index(anchor, cursor)
-                    end = start + len(anchor)
-                    if not any(replacement_flags[start:end]):
-                        entity_token = f'##{entity}##'.replace(' ', '_')
-                        text = text[:start] + entity_token + text[end:]
-                        replacement_flags = replacement_flags[:start] \
-                            + [1] * len(entity_token) + replacement_flags[end:]
-                        assert len(text) == len(replacement_flags)
-                        cursor = start + len(entity_token)
-                    else:
-                        cursor = end
+            if hyperlinks_sorted:
+                replace_map = {
+                    anchor: f'##{entity}##'.replace(' ', '_')
+                    for anchor, entity in hyperlinks_sorted.items()
+                }
+                pattern = re2.compile(
+                    '|'.join(re2.escape(a) for a in replace_map),
+                    re2.BESTMATCH,
+                )
+                text = pattern.sub(lambda m: replace_map[m.group(0)], text)
 
             text = ' '.join(tokenizer.tokenize(text))
 


### PR DESCRIPTION
## Summary
- use `regex` for fast hyperlink replacement in `make_corpus.py`
- mention the new dependency in the README

## Testing
- `python -m py_compile make_corpus.py tokenization.py train.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68497258e3a88332819f062f16bc02d5